### PR TITLE
Styling cleanup + docs update

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -136,7 +136,6 @@ Add buttons to the status bar:
            dash_prism.Action(
                id='save-btn',
                label='Save',
-               icon='Rocket',
                tooltip='Save workspace',
            ),
        ],
@@ -247,7 +246,6 @@ Use an Action to trigger reading the workspace. The Action provides the
            dash_prism.Action(
                id='export-btn',
                label='Export',
-               icon='Download',
                tooltip='Export workspace layout',
            ),
        ],
@@ -299,11 +297,11 @@ without replacing the entire workspace:
 
 .. code-block:: python
 
-   # Only update the theme
-   return {'theme': 'dark'}
-
    # Only update favorite layouts
    return {'favoriteLayouts': ['dashboard', 'analytics']}
+
+   # Only update which panel is active
+   return {'activePanelId': 'panel-abc'}
 
 Server-Side Persistence Pattern
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -316,8 +314,8 @@ persistence (useful when users access their workspace from multiple devices):
    dash_prism.Prism(
        id='workspace',
        actions=[
-           dash_prism.Action(id='save-btn', label='Save', icon='Save'),
-           dash_prism.Action(id='load-btn', label='Load', icon='FolderOpen'),
+           dash_prism.Action(id='save-btn', label='Save'),
+           dash_prism.Action(id='load-btn', label='Load'),
        ],
    )
 

--- a/src/ts/components/PrismActionComponent.tsx
+++ b/src/ts/components/PrismActionComponent.tsx
@@ -8,8 +8,8 @@ const ACTION_VARIANT_CLASSES: Record<string, string> = {
   default: '',
   primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
   secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-  success: 'bg-green-600 text-white hover:bg-green-600/90',
-  warning: 'bg-amber-500 text-white hover:bg-amber-500/90',
+  success: 'bg-success text-success-foreground hover:bg-success/90',
+  warning: 'bg-warning text-warning-foreground hover:bg-warning/90',
   danger: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
 };
 
@@ -18,6 +18,21 @@ const ACTION_VARIANT_CLASSES: Record<string, string> = {
  */
 function isHexColor(value: string): boolean {
   return /^#([0-9A-Fa-f]{3}){1,2}$/.test(value);
+}
+
+/**
+ * Compute a contrasting text color (black or white) for a given hex background.
+ * Uses relative luminance to ensure WCAG-compliant contrast.
+ */
+function getContrastColor(hex: string): string {
+  const full = hex.length === 4
+    ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
+    : hex;
+  const r = parseInt(full.slice(1, 3), 16);
+  const g = parseInt(full.slice(3, 5), 16);
+  const b = parseInt(full.slice(5, 7), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? '#000' : '#fff';
 }
 
 type PrismActionProps = {
@@ -82,7 +97,9 @@ export function PrismAction({
   const isCustomColor = variant && isHexColor(variant);
   const variantClasses =
     !isCustomColor && variant in ACTION_VARIANT_CLASSES ? ACTION_VARIANT_CLASSES[variant] : '';
-  const customStyle = isCustomColor ? { backgroundColor: variant, color: '#fff' } : undefined;
+  const customStyle = isCustomColor
+    ? { backgroundColor: variant, color: getContrastColor(variant) }
+    : undefined;
 
   // Tooltip content
   const tooltipContent = tooltip ?? `Click to trigger "${label}"`;

--- a/src/ts/components/PrismActionComponent.tsx
+++ b/src/ts/components/PrismActionComponent.tsx
@@ -25,9 +25,7 @@ function isHexColor(value: string): boolean {
  * Uses relative luminance to ensure WCAG-compliant contrast.
  */
 function getContrastColor(hex: string): string {
-  const full = hex.length === 4
-    ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
-    : hex;
+  const full = hex.length === 4 ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}` : hex;
   const r = parseInt(full.slice(1, 3), 16);
   const g = parseInt(full.slice(3, 5), 16);
   const b = parseInt(full.slice(5, 7), 16);

--- a/src/ts/components/ui/button.tsx
+++ b/src/ts/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',

--- a/src/ts/global.css
+++ b/src/ts/global.css
@@ -32,29 +32,20 @@
   --accent: oklch(0.205 0 0);
   --accent-foreground: oklch(0.97 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(1 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
+  --success: oklch(0.587 0.158 149.57);
+  --success-foreground: oklch(1 0 0);
+  --warning: oklch(0.788 0.171 74.59);
+  --warning-foreground: oklch(0.15 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
   --radius: 0.625rem;
-  --sidebar: oklch(0.96 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-
-  /* Prism surface zones (light) */
-  --prism-zone-tabbar: var(--background);
-  --prism-zone-workspace: var(--background);
-  --prism-zone-searchbar: var(--background);
 
   /* Tab colors (light mode - saturated for visibility) */
   --tab-red: oklch(0.6 0.22 25);
@@ -97,19 +88,10 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.22 0 0);
-  --sidebar-foreground: oklch(0.87 0 0);
-  --sidebar-primary: oklch(0.87 0 0);
-  --sidebar-primary-foreground: oklch(0.22 0 0);
-  --sidebar-accent: oklch(0.26 0 0);
-  --sidebar-accent-foreground: oklch(0.87 0 0);
-  --sidebar-border: oklch(0.33 0 0);
-  --sidebar-ring: oklch(0.44 0 0);
-
-  /* Prism surface zones (dark) */
-  --prism-zone-tabbar: var(--background);
-  --prism-zone-workspace: var(--background);
-  --prism-zone-searchbar: var(--muted);
+  --success: oklch(0.587 0.158 149.57);
+  --success-foreground: oklch(1 0 0);
+  --warning: oklch(0.788 0.171 74.59);
+  --warning-foreground: oklch(0.15 0 0);
 
   /* Tab colors (dark mode - softer for dark backgrounds) */
   --tab-red: oklch(0.75 0.16 20);
@@ -149,6 +131,10 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -163,16 +149,6 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
-
-  /* Sidebar */
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
 }
 
 /* =============================================================================


### PR DESCRIPTION
styling: Swap hardcoded colors for semantic tokens, drop unused CSS variables
- --destructive-foreground was identical to --destructive in light mode (red text on red background). Now white, matching dark mode.
- button.tsx destructive variant: text-white -> text-destructive-foreground
- Added --success/--warning token pairs (OKLch equivalents of the old Tailwind green-600 and amber-500 values, same appearance) 
- PrismActionComponent: bg-green-600/bg-amber-500 -> bg-success/bg-warning
- Custom hex colors now compute contrast instead of assuming white text
- Removed --sidebar-* and --prism-zone-* tokens (defined but never used)

docs: fix inaccurate Action and updateWorkspace examples in user guide
- Remove non-existent `icon` parameter from Action examples and replace `theme` (a direct Dash prop) with `activePanelId` in the updateWorkspace partial update example to reflect actual workspace state fields.